### PR TITLE
Fix issues that break some YAML parsers

### DIFF
--- a/schemas/entities/file.yml
+++ b/schemas/entities/file.yml
@@ -90,7 +90,6 @@ attributes:
 - name: previous_changed_time
   type: date
   description: When the file was previously changed
-  type: date
   sample_value: 2016-11-25 18:21:47
 - name: previous_creation_time
   type: date

--- a/schemas/entities/source_nat.yml
+++ b/schemas/entities/source_nat.yml
@@ -3,6 +3,6 @@ prefix:
 - src_nat
 id: 034C3864-6220-475D-98DD-DDE36A88E7CA
 description: Event fields used to define the destination NAT (network address translation) in a network connection event.
-attributes:
+attributes: []
 references: []
 tags: []


### PR DESCRIPTION
Fixes the following issues that cause some errors while parsing the source YAML:

- Removes a duplicate `type` key on the `previous_changed_time` attribute of the `file` entity.
- Adds an empty list qualifier to `attributes` in the `src_nat` entity.