### PR TITLE
Initial revamp of the OSSEM Project - Common Data Model component 

### DIFF
--- a/schemas/entities/file.yml
+++ b/schemas/entities/file.yml
@@ -1,11 +1,13 @@
 name: file
 prefix:
 - file
+- file_previous
 id: E94FB7C5-185A-459F-8C27-87600E32E598
 description: Event fields used to define/normalize metadata about files either locally or over the wire (Network Traffic). This entity and attributes can extend other entities such as source and destination.
 extends_entities:
 - source
 - destination
+- process
 attributes:
 - name: name
   type: string
@@ -83,30 +85,6 @@ attributes:
   type: date
   description: When the file was last modified. Also known as `mtime`
   sample_value: 2016-11-25 18:21:47
-- name: previous_accessed_time
-  type: date
-  description: When the file was previously accessed
-  sample_value: 2016-11-25 18:21:47
-- name: previous_changed_time
-  type: date
-  description: When the file was previously changed
-  sample_value: 2016-11-25 18:21:47
-- name: previous_creation_time
-  type: date
-  description: When the file was previously created
-  sample_value: 2016-11-25 18:21:47
-- name: previous_modified_time
-  type: date
-  description: When the file was previously modified
-  sample_value: 2016-11-25 18:21:47
-- name: previous_name
-  type: string
-  description: The file's previous name
-  sample_value: cmd.exe
-- name: previous_path
-  type: string
-  description: The file's previous path
-  sample_value: C:\\Windows\system32\cmd.exe
 - name: system_type
   type: string
   description: 'The file system type, ex:  fat32, ntfs, vmfs, ext3, ext4, xfs'

--- a/schemas/entities/process.yml
+++ b/schemas/entities/process.yml
@@ -28,30 +28,6 @@ attributes:
   type: string
   description: The full path to the current directory for the process. The string can also specify a UNC path.
   sample_value: C:\Users\Panda\Test
-- name: file_name
-  type: string
-  description: Name of the Image file or executable file used to define the initial code and data mapped into the process' virtual address space. This does not contain the full patth of the Image file.
-  sample_value: conhost.exe
-- name: file_path
-  type: string
-  description: The complete path and name of the Image file or executable file used to define the initial code and data mapped into the process' virtual address space.
-  sample_value: C:\Windows\System32\conhost.exe
-- name: file_version
-  type: string
-  description: Version of the Image file
-  sample_value: 10.0.16299.15 (WinBuild.160101.0800)
-- name: file_description
-  type: string
-  description: Description of the Image file
-  sample_value: Console Window Host
-- name: file_product
-  type: string
-  description: The Image's file product name
-  sample_value: "Microsoft Windows Operating System"
-- name: company
-  type: string
-  description: Company name metadata of the Image file
-  sample_value: Microsoft Corporation
 - name: command_line
   type: string
   description: Command arguments that were were executed by the process in the endpoint.

--- a/schemas/entities/registry.yml
+++ b/schemas/entities/registry.yml
@@ -1,6 +1,7 @@
 name: registry
 prefix:
 - registry
+- registry_modified
 id: 46295005-AC42-41CA-A45E-4CB669E39030
 description: Event fields used to define metadata about Windows registry entries in a system.
   The registry is a hierarchical database that contains data that is critical for the operation of Windows and the applications and services that run on Windows.
@@ -44,32 +45,16 @@ attributes:
     Registry key value data store the actual configuration data for the operating system and the programs that run on the system.
     As such, they are different from subtrees, keys, and subkeys, which are merely containers.
   sample_value: 'C:\Path\malware'
-- name: key_path_modified
-  type: string
-  description: Original registry key path before being modified.
-  sample_value: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\WardogPersistence
-- name: key_name_modified
-  type: string
-  description: Original registry key name before being modified.
-  sample_value: Run
-- name: value_name_modified
-  type: string
-  description: Original registry key vakue name before being modified.
-  sample_value: WardogPersistence
-- name: value_type_modified
-  type: string
-  description: Original registry key vakue type before being modified.
-  sample_value: REG_EXPAND_SZ
-- name: value_data_modified
-  type: string
-  description: Original registry key value data before being modified.
-  sample_value: C:\malware.exe
 - name: key_access_rights
   type: string
   description: The Windows security model enables you to control access to registry keys.
     The valid access rights for registry keys include the DELETE, READ_CONTROL, WRITE_DAC, and WRITE_OWNER standard access rights.
     Registry keys do not support the SYNCHRONIZE standard access right.
   sample_value: KEY_ALL_ACCESS (0xF003F)
+- name: event_type
+  type: string
+  description: Describes the activity around registry keys and values such as creation, deletion and modification.
+  sample_value: CreateKey
 references:
 - https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
 - https://docs.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry

--- a/schemas/entities/registry.yml
+++ b/schemas/entities/registry.yml
@@ -1,7 +1,7 @@
 name: registry
 prefix:
 - registry
-- registry_modified
+- registry_previous
 id: 46295005-AC42-41CA-A45E-4CB669E39030
 description: Event fields used to define metadata about Windows registry entries in a system.
   The registry is a hierarchical database that contains data that is critical for the operation of Windows and the applications and services that run on Windows.
@@ -29,6 +29,10 @@ attributes:
   type: string
   description: This field contains the key name without the full path. Take in consideration the name of the key value in the registry key path.
   sample_value: Run
+- name: key_handle_id
+  type: string
+  description: This field contains the hexadecimal value of the handle requested to the registry key.
+  sample_value: '0xa40'
 - name: value_name
   type: string
   description: Registry values are the lowest-level element in the registry.


### PR DESCRIPTION
**Process**:
- Removed `file related` fields from process entity and added `process as extended entity` in file entity. We can still use fields such as process_file_path.

**File**:
- Removed `previous related` fields from file entity and added `file_previous` prefix to file entity. We can model modifications of file attributes such as `file_previous_creation_time`.

**Registry**:
- Removed `modified related` fields from registry entity and added `registry_previous` prefix to registry entity. We can model modifications of registry attributes such as `registry_previous_value_data`.
- Added 2 new attributes: `key_handle_id` and `event_type`. We still need to validate these standard names with other telemetry sources than Security and Sysmon.